### PR TITLE
Исправить пустой экран TGWR в Electron sandbox

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       rollupOptions: {
         input: resolve('src/preload/index.ts'),
         output: {
+          format: 'cjs',
           entryFileNames: 'index.js'
         }
       }

--- a/scripts/packaged-app-smoke.mjs
+++ b/scripts/packaged-app-smoke.mjs
@@ -42,20 +42,20 @@ await new Promise((resolvePromise, reject) => {
 
   const inspect = (chunk) => {
     output += chunk.toString('utf8')
-    if (output.includes('tgwr_packaged_worker_smoke=ok')) {
-      console.log('packaged_app_smoke=ok bundled_worker=pong')
+    if (output.includes('tgwr_packaged_app_smoke=ok worker=pong renderer=ready')) {
+      console.log('packaged_app_smoke=ok bundled_worker=pong renderer=ready')
       finish()
     }
   }
 
   const timeout = setTimeout(() => {
-    finish(new Error(`Установленное приложение не дождалось pong от worker.\n${output.slice(-4000)}`))
+    finish(new Error(`Установленное приложение не подтвердило готовность интерфейса и worker.\n${output.slice(-4000)}`))
   }, 20_000)
 
   child.stdout.on('data', inspect)
   child.stderr.on('data', inspect)
   child.on('error', finish)
   child.on('exit', (code) => {
-    if (!settled) finish(new Error(`Приложение завершилось до проверки worker (code=${code ?? 'null'}).\n${output.slice(-4000)}`))
+    if (!settled) finish(new Error(`Приложение завершилось до проверки интерфейса и worker (code=${code ?? 'null'}).\n${output.slice(-4000)}`))
   })
 })

--- a/scripts/synthetic-smoke.mjs
+++ b/scripts/synthetic-smoke.mjs
@@ -1130,6 +1130,7 @@ function renderHarnessHtml(report, assets, slideIndex) {
       });
       window.__TGWR_REPORT__ = ${JSON.stringify(report)};
       window.tgwr = {
+        rendererReady: () => {},
         onWorkerEvent: () => () => {},
         pingWorker: () => {},
         importExport: () => {},

--- a/scripts/verify-package-contents.mjs
+++ b/scripts/verify-package-contents.mjs
@@ -1,4 +1,4 @@
-import { readdir, stat } from 'node:fs/promises'
+import { readFile, readdir, stat } from 'node:fs/promises'
 import { dirname, join, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -7,6 +7,17 @@ const releaseDir = join(root, 'release')
 const executableName = process.platform === 'win32' ? 'tgwr-worker.exe' : 'tgwr-worker'
 const expectedSuffix = ['worker-bin', `${process.platform}-${process.arch}`, executableName].join('/')
 const files = []
+
+const preloadPath = join(root, 'dist', 'preload', 'index.js')
+let preloadSource = ''
+try {
+  preloadSource = await readFile(preloadPath, 'utf8')
+} catch {
+  throw new Error('Не найден CommonJS preload dist/preload/index.js')
+}
+if (!preloadSource.includes('require("electron")')) {
+  throw new Error('Preload собран не в CommonJS и не сможет работать внутри Electron sandbox')
+}
 
 async function walk(directory) {
   for (const entry of await readdir(directory, { withFileTypes: true })) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -21,6 +21,7 @@ const IPC_WRITE_OUTPUT_FILE = 'tgwr:write-output-file' as const
 const IPC_LOAD_REPORT = 'tgwr:load-report' as const
 const IPC_RESET_REPORT = 'tgwr:reset-report' as const
 const IPC_DELETE_ALL_DATA = 'tgwr:delete-all-data' as const
+const IPC_RENDERER_READY = 'tgwr:renderer-ready' as const
 
 if (process.platform === 'linux') {
   app.disableHardwareAcceleration()
@@ -63,9 +64,21 @@ let lastKnownStatus: WorkerStatusEvent = {
   message: 'Worker not started',
   ts: new Date().toISOString()
 }
+let smokeWorkerPong = false
+let smokeRendererReady = false
+let smokeExitScheduled = false
 
 function nowIso(): string {
   return new Date().toISOString()
+}
+
+function finishPackagedSmokeWhenReady(): void {
+  if (process.env.TGWR_SMOKE_EXIT_ON_PONG !== '1') return
+  if (!smokeWorkerPong || !smokeRendererReady || smokeExitScheduled) return
+
+  smokeExitScheduled = true
+  console.log('tgwr_packaged_app_smoke=ok worker=pong renderer=ready')
+  setTimeout(() => app.quit(), 50)
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -188,13 +201,9 @@ function handleWorkerStdoutChunk(text: string): void {
     }
 
     emitToRenderer(parsed)
-    if (
-      process.env.TGWR_SMOKE_EXIT_ON_PONG === '1' &&
-      isPlainObject(parsed) &&
-      parsed.type === 'pong'
-    ) {
-      console.log('tgwr_packaged_worker_smoke=ok')
-      setTimeout(() => app.quit(), 50)
+    if (isPlainObject(parsed) && parsed.type === 'pong') {
+      smokeWorkerPong = true
+      finishPackagedSmokeWhenReady()
     }
   }
 }
@@ -636,6 +645,11 @@ async function forwardImportExport(exportDir: unknown): Promise<void> {
 
 ipcMain.on(IPC_WORKER_PING, () => {
   sendToWorker({ cmd: 'ping' })
+})
+
+ipcMain.on(IPC_RENDERER_READY, () => {
+  smokeRendererReady = true
+  finishPackagedSmokeWhenReady()
 })
 
 ipcMain.on(IPC_WORKER_CANCEL, () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,6 +11,7 @@ const IPC_WRITE_OUTPUT_FILE = 'tgwr:write-output-file' as const
 const IPC_LOAD_REPORT = 'tgwr:load-report' as const
 const IPC_RESET_REPORT = 'tgwr:reset-report' as const
 const IPC_DELETE_ALL_DATA = 'tgwr:delete-all-data' as const
+const IPC_RENDERER_READY = 'tgwr:renderer-ready' as const
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -59,6 +60,7 @@ export type DataMutationResult =
     }
 
 export interface TgwrApi {
+  rendererReady: () => void
   onWorkerEvent: (cb: (payload: unknown) => void) => () => void
   pingWorker: () => void
   importExport: (exportDir: string) => void
@@ -80,6 +82,8 @@ function normalizeDataMutationResult(value: unknown): DataMutationResult {
 }
 
 const api: TgwrApi = {
+  rendererReady: () => ipcRenderer.send(IPC_RENDERER_READY),
+
   onWorkerEvent: (cb) => {
     const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => cb(payload)
     ipcRenderer.on(IPC_WORKER_EVENT, listener)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -211,6 +211,11 @@ export default function App(): JSX.Element {
   }, [theme])
 
   useEffect(() => {
+    const timer = window.setTimeout(() => window.tgwr.rendererReady(), 0)
+    return () => window.clearTimeout(timer)
+  }, [])
+
+  useEffect(() => {
     importRunningRef.current = importRunning
   }, [importRunning])
 

--- a/src/renderer/src/global.d.ts
+++ b/src/renderer/src/global.d.ts
@@ -45,6 +45,7 @@ declare global {
 
   interface Window {
     tgwr: {
+      rendererReady: () => void
       onWorkerEvent: (cb: (payload: unknown) => void) => () => void
       pingWorker: () => void
       importExport: (exportDir: string) => void

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -3,8 +3,61 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import './styles.css'
 
+type RendererErrorBoundaryState = {
+  error: Error | null
+}
+
+class RendererErrorBoundary extends React.Component<React.PropsWithChildren, RendererErrorBoundaryState> {
+  state: RendererErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): RendererErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error('TGWR renderer crashed', error, info.componentStack)
+  }
+
+  render(): React.ReactNode {
+    if (!this.state.error) return this.props.children
+
+    return (
+      <main
+        data-testid="renderer-error"
+        style={{
+          minHeight: '100vh',
+          display: 'grid',
+          placeItems: 'center',
+          padding: 32,
+          boxSizing: 'border-box'
+        }}
+      >
+        <section style={{ maxWidth: 680, textAlign: 'center' }}>
+          <p style={{ color: '#78c8ff', letterSpacing: '0.18em', textTransform: 'uppercase' }}>TGWR</p>
+          <h1>Не удалось запустить интерфейс</h1>
+          <p style={{ color: '#a9b7c6', lineHeight: 1.6 }}>
+            Локальные данные не удалены. Перезапусти приложение; если экран появится снова, передай разработчику текст ошибки ниже.
+          </p>
+          <pre style={{ whiteSpace: 'pre-wrap', color: '#ffb4b4', overflowWrap: 'anywhere' }}>
+            {this.state.error.message}
+          </pre>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            style={{ marginTop: 12, padding: '10px 18px', cursor: 'pointer' }}
+          >
+            Перезапустить интерфейс
+          </button>
+        </section>
+      </main>
+    )
+  }
+}
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <RendererErrorBoundary>
+      <App />
+    </RendererErrorBoundary>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Что исправлено

Electron открывал окно TGWR, но показывал только тёмный фон без интерфейса. Локальная база и отчёт при этом не повреждались.

## Корневая причина

После включения `sandbox: true` preload продолжал собираться как ESM-файл `index.mjs`, потому что проект использует `type: module`. Sandboxed preload Electron не мог исполнить этот файл, поэтому `contextBridge` не создавал `window.tgwr`. React падал при первой попытке подписаться на события worker.

## Что изменено

- preload принудительно собирается в CommonJS `dist/preload/index.js`;
- `contextIsolation` и renderer sandbox остаются включёнными;
- renderer подтверждает успешное монтирование отдельным узким IPC-сигналом;
- packaged-app smoke ждёт одновременно `renderer=ready` и `worker=pong`;
- package-check отклоняет preload, собранный не в CommonJS;
- synthetic harness поддерживает новый handshake;
- React error boundary показывает понятную ошибку и кнопку перезапуска вместо пустого экрана.

## Зачем усилен smoke

Прежний smoke завершался после pong от worker. Worker мог работать исправно даже при полностью упавшем renderer, поэтому CI давал ложный PASS. Теперь именно такой регресс блокирует сборку.

## Проверка

Локально:

```bash
npm run verify
```

PASS:

- TypeScript;
- 5 fixture-тестов импорта;
- synthetic metric/schema contract;
- PyInstaller worker build и pong;
- Electron package contents и CommonJS preload;
- реальная packaged-сборка: `renderer=ready` и `bundled worker=pong`.

GitHub Actions на коммите `5fcc87b`:

- полный synthetic и browser smoke;
- Linux x64 package с реальным запуском sandboxed Electron;
- Windows x64 package;
- macOS x64 package;
- macOS ARM64 package.

Run: https://github.com/iwannasome/TGWRDSKTP/actions/runs/29111242063

Захардкоженные Telegram ID, московское время и пользовательские данные этим исправлением не затрагиваются.
