### PR TITLE
Закрыть все предупреждения CodeQL перед stable-релизом

### DIFF
--- a/scripts/synthetic-smoke.mjs
+++ b/scripts/synthetic-smoke.mjs
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from 'node:child_process'
-import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { createServer } from 'node:http'
 import { tmpdir, userInfo } from 'node:os'
@@ -7,7 +7,10 @@ import { dirname, join, resolve } from 'node:path'
 
 const root = resolve(dirname(new URL(import.meta.url).pathname), '..')
 const smokeUser = userInfo().username.replace(/[^a-zA-Z0-9_.-]/g, '_')
-const workDir = process.env.TGWR_SMOKE_WORKDIR || join(tmpdir(), `tgwr-synthetic-smoke-${smokeUser}`)
+const configuredWorkDir = process.env.TGWR_SMOKE_WORKDIR?.trim()
+const workDir = configuredWorkDir
+  ? resolve(configuredWorkDir)
+  : await mkdtemp(join(tmpdir(), `tgwr-synthetic-smoke-${smokeUser}-`))
 const exportDir = join(workDir, 'TelegramExportSynthetic')
 const outDir = join(workDir, 'out')
 const screenshotsDir = join(workDir, 'screenshots')
@@ -126,7 +129,7 @@ function makeSegmentedMessages({ peerId, peerName, segments }) {
 }
 
 async function generateExport() {
-  await rm(workDir, { recursive: true, force: true })
+  if (configuredWorkDir) await rm(workDir, { recursive: true, force: true })
   await mkdir(exportDir, { recursive: true })
   await mkdir(outDir, { recursive: true })
   await mkdir(screenshotsDir, { recursive: true })
@@ -1386,8 +1389,14 @@ function renderHarnessHtml(report, assets, slideIndex) {
 
 function assertHarnessInlineScriptParses(report) {
   const html = renderHarnessHtml(report, { cssFile: 'smoke.css', jsFile: 'smoke.js' }, 0)
-  const inlineScript = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
-  if (!inlineScript) throw new Error('Synthetic harness is missing its inline bootstrap script')
+  const startMarker = '<script>'
+  const endMarker = '</script>'
+  const scriptStart = html.indexOf(startMarker)
+  const scriptEnd = scriptStart === -1 ? -1 : html.indexOf(endMarker, scriptStart + startMarker.length)
+  if (scriptStart === -1 || scriptEnd === -1) {
+    throw new Error('Synthetic harness is missing its inline bootstrap script')
+  }
+  const inlineScript = html.slice(scriptStart + startMarker.length, scriptEnd)
   try {
     new Function(inlineScript)
   } catch (error) {
@@ -1415,8 +1424,9 @@ async function startHarnessServer(report) {
       res.setHeader('Content-Type', 'text/html; charset=utf-8')
       res.end(renderHarnessHtml(report, assets, Number.isFinite(slideIndex) ? slideIndex : 0))
     } catch (err) {
+      console.error('Synthetic harness request failed', err)
       res.statusCode = 500
-      res.end(err instanceof Error ? err.message : String(err))
+      res.end('Synthetic harness request failed')
     }
   })
 

--- a/worker/tests/test_import_fixtures.py
+++ b/worker/tests/test_import_fixtures.py
@@ -30,6 +30,7 @@ from tgwr_worker import (  # noqa: E402
     scan_export_dir,
     load_json_safely,
     ensure_import_disk_capacity,
+    extract_emojis,
     _pick_person_by_time_profile,
     MAX_INFERRED_REPLY_SECONDS,
 )
@@ -120,6 +121,10 @@ class ImportFixtureTests(unittest.TestCase):
         self.assertIsNotNone(selected)
         self.assertEqual(selected.get("total_messages"), 3000)
         self.assertEqual(MAX_INFERRED_REPLY_SECONDS, 48 * 60 * 60)
+
+    def test_emoji_extraction_keeps_emoji_and_skips_other_unicode_symbols(self):
+        self.assertEqual(extract_emojis("готово 🔥✨ 🇷🇺"), ["🔥", "✨", "🇷", "🇺"])
+        self.assertEqual(extract_emojis("не эмодзи: A, 1, ™, ♯, ❨"), [])
 
     def test_html_group_is_detected_but_personal_chat_is_kept(self):
         group_file = os.path.join(FIXTURES_DIR, "html_group", "messages.html")

--- a/worker/tgwr_worker.py
+++ b/worker/tgwr_worker.py
@@ -8,6 +8,7 @@ import sqlite3
 import statistics
 import sys
 import threading
+import unicodedata
 import ijson
 from bisect import bisect_left, bisect_right
 from collections import Counter, defaultdict
@@ -2155,21 +2156,19 @@ _URL_RE = re.compile(
 
 _WORD_RE = re.compile(r"[A-Za-zА-Яа-яЁё]{2,}", flags=re.UNICODE)
 
-_EMOJI_RE = re.compile(
-    "["
-    "\U0001F1E0-\U0001F1FF"
-    "\U0001F300-\U0001F5FF"
-    "\U0001F600-\U0001F64F"
-    "\U0001F680-\U0001F6FF"
-    "\U0001F700-\U0001F77F"
-    "\U0001F780-\U0001F7FF"
-    "\U0001F800-\U0001F8FF"
-    "\U0001F900-\U0001F9FF"
-    "\U0001FA00-\U0001FAFF"
-    "\u2600-\u26FF"
-    "\u2700-\u27BF"
-    "]"
+_EMOJI_CODEPOINT_RANGES = (
+    (0x1F1E6, 0x1F1FF),
+    (0x1F300, 0x1FAFF),
+    (0x2600, 0x26FF),
+    (0x2700, 0x27BF),
 )
+
+
+def _is_emoji_codepoint(character: str) -> bool:
+    codepoint = ord(character)
+    if not any(start <= codepoint <= end for start, end in _EMOJI_CODEPOINT_RANGES):
+        return False
+    return unicodedata.category(character) in {"So", "Sk"}
 
 
 def _strip_urls(text: str) -> str:
@@ -2201,7 +2200,7 @@ def extract_emojis(text: str) -> List[str]:
     if not text:
         return []
     s = _strip_urls(text)
-    return _EMOJI_RE.findall(s)
+    return [character for character in s if _is_emoji_codepoint(character)]
 
 
 def _median_int(values: List[int]) -> int:


### PR DESCRIPTION
## Что обнаружено

Финальный аудит default branch показал 11 открытых предупреждений CodeQL, хотя обязательные workflow завершались успешно. Это не были уязвимости в обработке пользовательского Telegram-архива, но оставлять незакрытые security findings перед stable-релизом нельзя.

## Что исправлено

- synthetic smoke больше не переиспользует предсказуемый каталог в системном `/tmp`: по умолчанию создаётся уникальная приватная директория через `mkdtemp`;
- подробности внутренних исключений локального тестового HTTP-сервера остаются в stderr и не возвращаются клиенту;
- проверка inline bootstrap больше не пытается разбирать HTML регулярным выражением;
- поиск эмодзи больше не считает эмодзи любой символ, случайно попавший в широкий Unicode-блок: кодпоинт дополнительно проверяется по Unicode-категории;
- добавлен регрессионный тест для обычных эмодзи, флага и похожих символов `♯`/`❨`, которые не должны попадать в статистику.

## Почему это важно

Изменение одновременно очищает цепочку security-аудита и делает метрику эмодзи точнее. Runtime-архитектура, hardcoded ID и московский часовой пояс не менялись.

## Проверка

- `npm run verify` — PASS;
- 16 worker-тестов — PASS;
- security и signing smoke — PASS;
- packaged app + worker restart + CSP — PASS;
- single-instance smoke — PASS;
- `npm audit --audit-level=moderate` — 0 уязвимостей;
- `git diff --check` — PASS.

Браузерные скриншоты локально пропущены, потому что Chrome отсутствует в PATH; нативные GitHub checks должны выполнить их перед слиянием.